### PR TITLE
Allow for non-expiring tokens. Ugh.

### DIFF
--- a/app/controllers/clickfunnels_auth/user_sessions_controller.rb
+++ b/app/controllers/clickfunnels_auth/user_sessions_controller.rb
@@ -24,7 +24,7 @@ class ClickfunnelsAuth::UserSessionsController < ClickfunnelsAuth::ApplicationCo
     user.access_tokens.create!({
       token: omniauth['credentials']['token'],
       refresh_token: omniauth['credentials']['refresh_token'],
-      expires_at: Time.at(omniauth['credentials']['expires_at'])
+      expires_at: omniauth['credentials']['expires_at'] ? Time.at(omniauth['credentials']['expires_at']) : omniauth['credentials']['expires_at']
     })
 
     session[:user_id] = user.id


### PR DESCRIPTION
We really shouldn't be issuing non-expiring tokens from the mothership, but we do, and this will account for that.