### PR TITLE
Removed dependency on rails ActiveStorage 

### DIFF
--- a/clickfunnels_auth.gemspec
+++ b/clickfunnels_auth.gemspec
@@ -15,7 +15,14 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 4.0.4"
+  s.add_dependency "activesupport", ">= 4.0.4"
+  s.add_dependency "actionpack", ">= 4.0.4"
+  s.add_dependency "actionview", ">= 4.0.4"
+  s.add_dependency "activemodel", ">= 4.0.4"
+  s.add_dependency "activerecord", ">= 4.0.4"
+  s.add_dependency "railties", ">= 4.0.4"
+
+
   s.add_dependency 'omniauth', ">= 1.3.1"
   s.add_dependency 'omniauth-oauth2', ">= 1.4.0"
 

--- a/lib/clickfunnels_auth/version.rb
+++ b/lib/clickfunnels_auth/version.rb
@@ -1,3 +1,3 @@
 module ClickfunnelsAuth
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Removed dependency on rails ActiveStorage so this gem is not relying on MimeMagic.

Ref: https://github.com/rails/rails/issues/41750